### PR TITLE
Alternative `Impossible` mechanism that allows unsaturated usage

### DIFF
--- a/src/Data/Constraint/Trivial.hs
+++ b/src/Data/Constraint/Trivial.hs
@@ -4,10 +4,12 @@
 -- License     :  GPL v3 (see LICENSE)
 -- Maintainer  :  (@) jsagemue $ uni-koeln.de
 --
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE ConstraintKinds         #-}
+{-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE MultiParamTypeClasses   #-}
+{-# LANGUAGE PolyKinds               #-}
+{-# LANGUAGE UndecidableInstances    #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Data.Constraint.Trivial (
             Unconstrained, Impossible
@@ -21,6 +23,8 @@ module Data.Constraint.Trivial (
           , Unconstrained9, Impossible9
           ) where
 
+import           GHC.Exts (Any)
+
 -- | Intended to be used as an argument for some type constructor which expects kind
 --   @k -> Constraint@, when you do not actually wish to constrain anything with it.
 --
@@ -33,9 +37,11 @@ instance Unconstrained t
 -- | This constraint can /never/ be fulfilled. Might be useful e.g. as a default
 --   for a class-associated constraint; this basically disables any method with
 --   that constraint (so it can safely be left 'undefined').
-type Impossible t = HiddenEmptyClass t
-
-class HiddenEmptyClass t
+--
+--   This implementation works by requiring any instance also satify the
+--   'Any' constraint, but the 'Any' constraint is impossible to ever
+--   fulfil.
+class Any => Impossible t
 
 
 -- | Like 'Unconstrained', but with kind signature @k -> k -> Constraint@
@@ -43,54 +49,46 @@ class HiddenEmptyClass t
 class Unconstrained2 t s
 instance Unconstrained2 t s
 
-type Impossible2 t s = HiddenEmptyClass2 t s
-class HiddenEmptyClass2 t s
+class Any => Impossible2 t s
 
 
 class Unconstrained3 t s r
 instance Unconstrained3 t s r
 
-type Impossible3 t s r = HiddenEmptyClass3 t s r
-class HiddenEmptyClass3 t s r
+class Any => Impossible3 t s r
 
 
 class Unconstrained4 t s r q
 instance Unconstrained4 t s r q
 
-type Impossible4 t s r q = HiddenEmptyClass4 t s r q
-class HiddenEmptyClass4 t s r q
+class Any => Impossible4 t s r q
 
 
 class Unconstrained5 t s r q p
 instance Unconstrained5 t s r q p
 
-type Impossible5 t s r q p = HiddenEmptyClass5 t s r q p
-class HiddenEmptyClass5 t s r q p
+class Any => Impossible5 t s r q p
 
 
 class Unconstrained6 t s r q p o
 instance Unconstrained6 t s r q p o
 
-type Impossible6 t s r q p o = HiddenEmptyClass6 t s r q p o
-class HiddenEmptyClass6 t s r q p o
+class Any => Impossible6 t s r q p o
 
 
 class Unconstrained7 t s r q p o n
 instance Unconstrained7 t s r q p o n
 
-type Impossible7 t s r q p o n = HiddenEmptyClass7 t s r q p o n
-class HiddenEmptyClass7 t s r q p o n
+class Any => Impossible7 t s r q p o n
 
 
 class Unconstrained8 t s r q p o n m
 instance Unconstrained8 t s r q p o n m
 
-type Impossible8 t s r q p o n m = HiddenEmptyClass8 t s r q p o n m
-class HiddenEmptyClass8 t s r q p o n m
+class Any => Impossible8 t s r q p o n m
 
 
 class Unconstrained9 t s r q p o n m l
 instance Unconstrained9 t s r q p o n m l
 
-type Impossible9 t s r q p o n m l = HiddenEmptyClass9 t s r q p o n m l
-class HiddenEmptyClass9 t s r q p o n m l
+class Any => Impossible9 t s r q p o n m l

--- a/src/Data/Constraint/Trivial.hs
+++ b/src/Data/Constraint/Trivial.hs
@@ -5,25 +5,31 @@
 -- Maintainer  :  (@) jsagemue $ uni-koeln.de
 --
 {-# LANGUAGE ConstraintKinds         #-}
+{-# LANGUAGE DataKinds               #-}
 {-# LANGUAGE FlexibleInstances       #-}
 {-# LANGUAGE MultiParamTypeClasses   #-}
 {-# LANGUAGE PolyKinds               #-}
+{-# LANGUAGE TypeOperators           #-}
 {-# LANGUAGE UndecidableInstances    #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Data.Constraint.Trivial (
-            Unconstrained, Impossible
-          , Unconstrained2, Impossible2
-          , Unconstrained3, Impossible3
-          , Unconstrained4, Impossible4
-          , Unconstrained5, Impossible5
-          , Unconstrained6, Impossible6
-          , Unconstrained7, Impossible7
-          , Unconstrained8, Impossible8
-          , Unconstrained9, Impossible9
+            Unconstrained, Impossible(..)
+          , Unconstrained2, Impossible2(..)
+          , Unconstrained3, Impossible3(..)
+          , Unconstrained4, Impossible4(..)
+          , Unconstrained5, Impossible5(..)
+          , Unconstrained6, Impossible6(..)
+          , Unconstrained7, Impossible7(..)
+          , Unconstrained8, Impossible8(..)
+          , Unconstrained9, Impossible9(..)
           ) where
 
-import           GHC.Exts (Any)
+import           GHC.TypeLits
+
+type Disallowed t = 'Text "All instances of "
+              ':<>: 'Text t
+              ':<>: 'Text " are disallowed."
 
 -- | Intended to be used as an argument for some type constructor which expects kind
 --   @k -> Constraint@, when you do not actually wish to constrain anything with it.
@@ -37,11 +43,16 @@ instance Unconstrained t
 -- | This constraint can /never/ be fulfilled. Might be useful e.g. as a default
 --   for a class-associated constraint; this basically disables any method with
 --   that constraint (so it can safely be left 'undefined').
---
---   This implementation works by requiring any instance also satify the
---   'Any' constraint, but the 'Any' constraint is impossible to ever
---   fulfil.
-class Any => Impossible t
+class TypeError (Disallowed "Impossible") => Impossible t where
+    -- | Ex falso quodlibet.  If you have @'Impossible' t@, you can do
+    -- anything.
+    --
+    -- Might be useful e.g. if you are inside a function wiht an
+    -- @'Impossible' t =>@ constraint, and you want to do something
+    -- impossible, like the constraint implies.
+    --
+    -- Analogous to 'Data.Void.absurd'.
+    absurdible :: proxy t -> a
 
 
 -- | Like 'Unconstrained', but with kind signature @k -> k -> Constraint@
@@ -49,46 +60,62 @@ class Any => Impossible t
 class Unconstrained2 t s
 instance Unconstrained2 t s
 
-class Any => Impossible2 t s
+class TypeError (Disallowed "Impossible2") => Impossible2 t s where
+    absurdible2 :: proxy t -> proxy s -> a
 
 
 class Unconstrained3 t s r
 instance Unconstrained3 t s r
 
-class Any => Impossible3 t s r
+class TypeError (Disallowed "Impossible3") => Impossible3 t s r where
+    absurdible3 :: proxy t -> proxy s -> proxy r -> a
 
 
 class Unconstrained4 t s r q
 instance Unconstrained4 t s r q
 
-class Any => Impossible4 t s r q
+class TypeError (Disallowed "Impossible4") => Impossible4 t s r q where
+    absurdible4 :: proxy t -> proxy s -> proxy r -> proxy q -> a
 
 
 class Unconstrained5 t s r q p
 instance Unconstrained5 t s r q p
 
-class Any => Impossible5 t s r q p
+class TypeError (Disallowed "Impossible5") => Impossible5 t s r q p where
+    absurdible5 :: proxy t -> proxy s -> proxy r -> proxy q -> proxy p -> a
 
 
 class Unconstrained6 t s r q p o
 instance Unconstrained6 t s r q p o
 
-class Any => Impossible6 t s r q p o
+class TypeError (Disallowed "Impossible6") => Impossible6 t s r q p o where
+    absurdible6 :: proxy t -> proxy s -> proxy r
+                -> proxy q -> proxy p -> proxy o
+                -> a
 
 
 class Unconstrained7 t s r q p o n
 instance Unconstrained7 t s r q p o n
 
-class Any => Impossible7 t s r q p o n
+class TypeError (Disallowed "Impossible7") => Impossible7 t s r q p o n where
+    absurdible7 :: proxy t -> proxy s -> proxy r -> proxy q
+                -> proxy p -> proxy o -> proxy n -> a
 
 
 class Unconstrained8 t s r q p o n m
 instance Unconstrained8 t s r q p o n m
 
-class Any => Impossible8 t s r q p o n m
+class TypeError (Disallowed "Impossible8") => Impossible8 t s r q p o n m where
+    absurdible8 :: proxy t -> proxy s -> proxy r -> proxy q
+                -> proxy p -> proxy o -> proxy n -> proxy m
+                -> a
 
 
 class Unconstrained9 t s r q p o n m l
 instance Unconstrained9 t s r q p o n m l
 
-class Any => Impossible9 t s r q p o n m l
+class TypeError (Disallowed "Impossible9") => Impossible9 t s r q p o n m l where
+    absurdible9 :: proxy t -> proxy s -> proxy r
+                -> proxy q -> proxy p -> proxy o
+                -> proxy n -> proxy m -> proxy l
+                -> a


### PR DESCRIPTION
Hi! :)  Thank you again for the great library, and thanks for the quick deployment of my previous PR :)

This one is also a slight usability tweak to allow the current API to be more general, to work around an issue I ran while using `Impossible` for one of my projects.

Before, the mechanism for implementing the `Impossible` family of typeclasses involved using a type synonym over a hidden typeclass.  This is effective, but a drawback is that `Impossible` cannot be used alone as a `* -> Constraint`; it always must appear as `Impossible t`.

So, it can't be used in a data type like:

```haskell
data DictC c a = c a => DictC

type Never = DictC Impossible    -- not allowed
```

This alternative mechanism is inspired by the *constraints* library's implementation of [`Bottom`](https://hackage.haskell.org/package/constraints-0.11/docs/Data-Constraint.html#t:Bottom), except we can get nice error messages with `TypeError`:

```haskell
instance Impossible Int where

-- ERROR:
-- * All instances of Impossible are disallowed.
-- * In the instance for 'Impossible Int'
-- 
```

GHC will always reject all instances of `Impossible` you try to define, and this method gives a better error output than the `Any =>` method from *constraints*.

An extra small change here too is that because `Impossible` is a real typeclass, we can give it a real method that allows us to take advantage of the promised impossibility of the constraint, if we are ever "in" an `Impossible t`:

```haskell
-- | If we ever had any instance of Impossible, we can make 'Void'
mkVoid :: forall t. Impossible t => t -> Void
mkVoid _ = absurdible (Proxy :: Proxy t)
```

Note that this change should be 100% backwards compatible, I think.  All old code using `Impossible` will still work as before.