### PR TITLE
Fix building with GHC 8.10

### DIFF
--- a/src/Data/Constraint/Trivial.hs
+++ b/src/Data/Constraint/Trivial.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE Rank2Types              #-}
 {-# LANGUAGE EmptyCase               #-}
 {-# LANGUAGE PolyKinds               #-}
+{-# LANGUAGE TypeInType              #-}
 {-# LANGUAGE TypeOperators           #-}
 {-# LANGUAGE UndecidableInstances    #-}
 {-# LANGUAGE UndecidableSuperClasses #-}

--- a/src/Data/Constraint/Trivial.hs
+++ b/src/Data/Constraint/Trivial.hs
@@ -47,7 +47,7 @@ class (Bottom, TypeError ('Text "All instances of "
 --   you are guaranteed that it can under no circumstances actually be invoked, you
 --   are allowed to to anything whatsoever, even create a value of an uninhabited unlifted
 --   type.
-nope :: forall (a :: TYPE rep). Bottom => a
+nope :: forall rep (a :: TYPE rep). Bottom => a
 nope = case no of
 
 -- | A constraint that is always/unconditionally fulfilled. This behaves the same


### PR DESCRIPTION
GHC 8.10 changes how kind variables need to be qualified; this explicitly qualifies `rep` in the type signature for `nope`.  Note that this is technically potentially a breaking change if anyone ever used `nope` with a type application (like `nope @Int`), but I don't think this likely to break any code currently written, since its return type is very easily inferred in most situations.